### PR TITLE
Fix fetch post data division file

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,23 +1,7 @@
 import Link from "next/link";
-import fs from "fs";
-import path from "path";
 import Markdown from "markdown-to-jsx";
-import matter from "gray-matter";
 import getPostMetadata from "@/components/getPostMetadata";
-import { revalidatePath } from "next/cache";
-import { notFound } from "next/navigation";
-
-const getPostContent = async (slug: string) => {
-  const folder = "content/";
-  const file = path.join(folder, `${slug}.md`);
-  if (!fs.existsSync(file)) {
-    notFound();
-  }
-  const content = fs.readFileSync(file, "utf8");
-  const matterResult = matter(content);
-  revalidatePath("/posts");
-  return matterResult;
-};
+import getPostData from "@/components/getPostData";
 
 export const generateStaticParams = async () => {
   const posts = getPostMetadata();
@@ -29,7 +13,7 @@ export const generateStaticParams = async () => {
 
 export default async function PostPage(props: any) {
   const slug = props.params.slug;
-  const post = await getPostContent(slug);
+  const post = await getPostData(slug);
   return (
     <div className="container max-w-[800px] mx-auto">
       <h2 className="text-xl text-center p-8">{post.data.title}</h2>

--- a/components/getPostData.ts
+++ b/components/getPostData.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import matter from "gray-matter";
+import path from "path";
+import { notFound } from "next/navigation";
+import { revalidatePath } from "next/cache";
+
+const getPostData = (slug: string): any => {
+  const folder = "content/";
+  const file = path.join(folder, `${slug}.md`);
+  if (!fs.existsSync(file)) {
+    notFound();
+  }
+
+  const content = fs.readFileSync(file, "utf8");
+  const matterResult = matter(content);
+  revalidatePath("/posts");
+  return matterResult;
+};
+
+export default getPostData;


### PR DESCRIPTION
Fix/fetch-post-data-division-file

- 引き続きVercelでデプロイした際、ポストのデータが表示されなかったためデータを取得するファイルを別に分ける変更をおこない開発環境で確認する